### PR TITLE
Set up CI and integration test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv sync
+      - name: Run linter
+        run: uv run ruff check .
+      - name: Run unit tests
+        run: uv run pytest -m "not integration" -v

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,7 @@
 name: Claude Code
 
+# The orchestrator agent handles both issue and PR comment triggers.
+# It classifies tasks and delegates to the appropriate agent (GitHub, coding, etc.).
 on:
   issue_comment:
     types: [created]
@@ -18,6 +20,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # Write permissions are required for the orchestrator agent's eco sync workflow,
+    # which creates branches, opens PRs, and comments on issues.
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,25 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv sync
+      - name: Run integration tests
+        run: uv run pytest -m integration -v --timeout=300
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `ci.yml` workflow: runs ruff linting and unit tests (`pytest -m "not integration"`) on every push to main and on all PRs targeting main. Uses `uv` for dependency management with Python 3.12.
- Add `integration.yml` workflow: runs integration tests (`pytest -m integration`) on pushes to main and via manual `workflow_dispatch`. Injects `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` from repository secrets with a 300-second timeout.
- Update `claude.yml` comments to clarify that the orchestrator agent handles both issue and PR comment triggers, and that write permissions are required for the eco sync workflow.

Closes #7

## Test plan
- [ ] Verify `ci.yml` triggers on a PR to main and passes the checkout, uv sync, ruff check, and pytest steps
- [ ] Verify `integration.yml` can be triggered manually via workflow_dispatch
- [ ] Verify `claude.yml` still functions correctly (comments-only change, no functional diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)