### PR TITLE
Add prompt templates for judge, router, and reviewer

### DIFF
--- a/orchestration/__init__.py
+++ b/orchestration/__init__.py
@@ -1,15 +1,1 @@
-"""Orchestration module for multi-agent systems."""
-
-from orchestration.judge import (
-    CriterionScore,
-    EvaluationCriterion,
-    EvaluationReport,
-    JudgeEngine,
-)
-
-__all__ = [
-    "EvaluationCriterion",
-    "CriterionScore",
-    "EvaluationReport",
-    "JudgeEngine",
-]
+"""Orchestration module for multi-agent coordination."""

--- a/orchestration/prompts/__init__.py
+++ b/orchestration/prompts/__init__.py
@@ -1,0 +1,33 @@
+"""Prompt templates for judge, router, and reviewer agents.
+
+This module provides deterministic string templates for LLM prompts.
+All prompts follow the design principles:
+- P3: Clear thinking first (reasoning before scores)
+- P5: Deterministic infrastructure (fixed templates with variable slots)
+- P11: Goal -> Code -> CLI -> Prompts -> Agents hierarchy
+- P16: Permission to fail (explicit uncertainty allowance)
+"""
+
+from orchestration.prompts.judge_prompts import (
+    bias_checklist_prompt,
+    pairwise_eval_prompt,
+    reference_eval_prompt,
+)
+from orchestration.prompts.router_prompt import (
+    classify_task_prompt,
+    decompose_task_prompt,
+)
+from orchestration.prompts.review_prompts import (
+    review_pr_prompt,
+    scrutinize_test_changes_prompt,
+)
+
+__all__ = [
+    "reference_eval_prompt",
+    "pairwise_eval_prompt",
+    "bias_checklist_prompt",
+    "classify_task_prompt",
+    "decompose_task_prompt",
+    "review_pr_prompt",
+    "scrutinize_test_changes_prompt",
+]

--- a/orchestration/prompts/judge_prompts.py
+++ b/orchestration/prompts/judge_prompts.py
@@ -1,1 +1,158 @@
-"""Prompt templates for LLM-as-judge evaluation."""
+"""Prompt templates for the judge agent.
+
+These prompts support evaluation tasks including reference-based scoring,
+pairwise comparison, and bias detection. All evaluation prompts require
+reasoning before scores (P3) and allow uncertainty expression (P16).
+"""
+
+
+def reference_eval_prompt(response: str, reference: str, rubric: str) -> str:
+    """Generate a prompt for evaluating a response against a reference.
+
+    Args:
+        response: The response to evaluate.
+        reference: The reference answer to compare against.
+        rubric: The evaluation criteria and scoring guidelines.
+
+    Returns:
+        A formatted prompt string for reference-based evaluation.
+    """
+    return f"""You are an expert evaluator. Your task is to assess a response against a reference answer using the provided rubric.
+
+## Reference Answer
+{reference}
+
+## Response to Evaluate
+{response}
+
+## Evaluation Rubric
+{rubric}
+
+## Instructions
+
+1. **Analyze the response**: Carefully read and understand the response in relation to the reference.
+2. **Apply the rubric**: Consider each criterion in the rubric systematically.
+3. **Reason before scoring**: Explain your reasoning for each aspect of the evaluation BEFORE providing any scores. Think through:
+   - What the response does well
+   - Where the response falls short compared to the reference
+   - Specific examples supporting your assessment
+4. **Score**: Only after completing your reasoning, provide your final score(s) according to the rubric.
+
+## Uncertainty Guidance
+
+If you are uncertain about any aspect of your evaluation, state your uncertainty explicitly. It is better to acknowledge ambiguity than to provide false confidence. For example:
+- "I am uncertain whether X meets criterion Y because..."
+- "The rubric is ambiguous regarding Z, so I am interpreting it as..."
+
+## Output Format
+
+### Reasoning
+[Your detailed reasoning here, addressing each rubric criterion]
+
+### Uncertainty (if any)
+[State any uncertainties or ambiguities]
+
+### Final Evaluation
+[Your scores and final judgment according to the rubric format]
+"""
+
+
+def pairwise_eval_prompt(response_a: str, response_b: str, rubric: str) -> str:
+    """Generate a prompt for pairwise comparison of two responses.
+
+    This prompt includes debiasing instructions to mitigate position bias
+    and other common comparison pitfalls.
+
+    Args:
+        response_a: The first response to compare.
+        response_b: The second response to compare.
+        rubric: The evaluation criteria for comparison.
+
+    Returns:
+        A formatted prompt string for pairwise evaluation.
+    """
+    return f"""You are an expert evaluator. Your task is to compare two responses and determine which better satisfies the evaluation criteria.
+
+## Response A
+{response_a}
+
+## Response B
+{response_b}
+
+## Evaluation Rubric
+{rubric}
+
+## Debiasing Instructions
+
+Be aware of and actively counteract these common biases:
+- **Position bias**: Do not favor a response simply because it appears first or second.
+- **Length bias**: Longer responses are not automatically better. Evaluate substance over volume.
+- **Verbosity bias**: Concise, accurate responses may be superior to verbose ones.
+- **Style bias**: Focus on correctness and completeness, not superficial style preferences.
+
+To counteract position bias specifically:
+1. Evaluate each response independently against the rubric first.
+2. Only then compare them directly.
+3. Ask yourself: "Would my judgment change if the responses were presented in reverse order?"
+
+## Instructions
+
+1. **Evaluate Response A**: Apply the rubric to Response A, noting strengths and weaknesses.
+2. **Evaluate Response B**: Apply the rubric to Response B, noting strengths and weaknesses.
+3. **Reason before deciding**: Compare your evaluations and explain your reasoning for which response is superior. Think through:
+   - How each response addresses the rubric criteria
+   - Direct comparisons on specific points
+   - Trade-offs between the responses
+4. **Make your decision**: Only after completing your reasoning, declare which response is better (or if they are equivalent).
+
+## Uncertainty Guidance
+
+If you are uncertain about which response is better, state this explicitly. It is acceptable to conclude:
+- "Both responses are roughly equivalent because..."
+- "I cannot confidently distinguish between them due to..."
+- "Response X is marginally better, but I have low confidence because..."
+
+## Output Format
+
+### Response A Analysis
+[Your evaluation of Response A against the rubric]
+
+### Response B Analysis
+[Your evaluation of Response B against the rubric]
+
+### Comparative Reasoning
+[Your comparison and reasoning]
+
+### Uncertainty (if any)
+[State any uncertainties]
+
+### Final Decision
+[A, B, or Equivalent, with brief justification]
+"""
+
+
+def bias_checklist_prompt() -> str:
+    """Generate a standalone bias checklist to append to any evaluation.
+
+    This checklist can be appended to other prompts to reinforce
+    bias awareness and mitigation.
+
+    Returns:
+        A formatted bias checklist string.
+    """
+    return """## Bias Checklist
+
+Before finalizing your evaluation, review this checklist:
+
+- [ ] **Position bias**: Have I favored content based on where it appeared rather than its merit?
+- [ ] **Length bias**: Have I equated length with quality?
+- [ ] **Familiarity bias**: Have I favored responses that match my training data more closely?
+- [ ] **Authority bias**: Have I been swayed by confident tone over actual correctness?
+- [ ] **Confirmation bias**: Have I sought evidence supporting my initial impression?
+- [ ] **Anchoring bias**: Have I let my first observation disproportionately influence my judgment?
+- [ ] **Halo effect**: Have I let one strong aspect of a response color my view of other aspects?
+
+If you answered yes to any of these, revisit your evaluation and adjust accordingly.
+
+Remember: If uncertain, state your uncertainty explicitly rather than defaulting to false confidence.
+"""

--- a/orchestration/prompts/review_prompts.py
+++ b/orchestration/prompts/review_prompts.py
@@ -1,1 +1,188 @@
-"""Prompt templates for code review evaluation."""
+"""Prompt templates for the reviewer agent.
+
+These prompts support code review tasks including PR diff review and
+test quality assessment. All prompts require reasoning before scores (P3)
+and allow uncertainty expression (P16).
+"""
+
+
+def review_pr_prompt(diff: str, rubric: str) -> str:
+    """Generate a prompt for reviewing a PR diff against a rubric.
+
+    Args:
+        diff: The git diff content to review.
+        rubric: The review criteria and guidelines.
+
+    Returns:
+        A formatted prompt string for PR review.
+    """
+    return f"""You are an expert code reviewer. Your task is to review a pull request diff against the provided rubric.
+
+## Pull Request Diff
+```diff
+{diff}
+```
+
+## Review Rubric
+{rubric}
+
+## Instructions
+
+1. **Understand the changes**: Read through the diff to understand what is being modified and why.
+2. **Apply the rubric**: Systematically evaluate each criterion in the rubric.
+3. **Reason before judging**: For each aspect of the review, explain your reasoning:
+   - What does the code do well?
+   - What concerns or issues do you see?
+   - Are there potential bugs, security issues, or maintainability problems?
+   - Does the code follow best practices and conventions?
+4. **Provide actionable feedback**: Only after reasoning, summarize your findings with specific, actionable suggestions.
+
+## Review Categories
+
+Consider these aspects during your review:
+- **Correctness**: Does the code do what it's supposed to do?
+- **Security**: Are there any security vulnerabilities?
+- **Performance**: Are there obvious performance issues?
+- **Maintainability**: Is the code readable and maintainable?
+- **Testing**: Are changes appropriately tested?
+- **Documentation**: Are changes appropriately documented?
+
+## Uncertainty Guidance
+
+If you are uncertain about any aspect of the code:
+- State what you are uncertain about
+- Explain why (missing context, unfamiliar pattern, etc.)
+- Suggest what information would help clarify
+
+For example:
+- "I am uncertain whether this change handles edge case X because..."
+- "Without seeing the full context of Y, I cannot determine if Z is correct..."
+
+It is better to flag uncertainty than to approve problematic code or block good code.
+
+## Output Format
+
+### Summary
+[Brief summary of what this PR does]
+
+### Detailed Review
+
+#### [Category/File/Section]
+- **Observation**: [What you noticed]
+- **Reasoning**: [Why this matters]
+- **Suggestion**: [Specific actionable feedback, if any]
+
+[Repeat for each significant finding...]
+
+### Uncertainty (if any)
+[Areas where you lack confidence or need more context]
+
+### Overall Assessment
+- **Approve / Request Changes / Comment**: [Your recommendation]
+- **Key Issues**: [List critical issues that must be addressed]
+- **Suggestions**: [List non-blocking improvements]
+"""
+
+
+def scrutinize_test_changes_prompt(test_diff: str) -> str:
+    """Generate a prompt to evaluate test quality and TDD compliance.
+
+    Args:
+        test_diff: The git diff of test file changes.
+
+    Returns:
+        A formatted prompt string for test review.
+    """
+    return f"""You are an expert test reviewer. Your task is to evaluate test changes for quality and TDD (Test-Driven Development) compliance.
+
+## Test Diff
+```diff
+{test_diff}
+```
+
+## Instructions
+
+1. **Understand the test changes**: Identify what tests are being added, modified, or removed.
+2. **Evaluate test quality**: Apply the quality criteria below systematically.
+3. **Reason before judging**: For each criterion, explain your reasoning:
+   - What makes these tests effective or ineffective?
+   - Are there gaps in coverage?
+   - Do the tests follow best practices?
+4. **Assess TDD compliance**: Consider whether tests drive the implementation or merely validate it after the fact.
+5. **Provide feedback**: Only after reasoning, summarize with actionable suggestions.
+
+## Test Quality Criteria
+
+- **Coverage**: Do tests cover the intended functionality, including edge cases?
+- **Isolation**: Are tests independent and not reliant on external state?
+- **Clarity**: Are test names and assertions clear about what they verify?
+- **Maintainability**: Will these tests be easy to maintain as code evolves?
+- **Speed**: Are tests appropriately fast (unit tests fast, integration tests acceptable)?
+- **Determinism**: Are tests deterministic (no flaky tests)?
+
+## TDD Compliance Indicators
+
+Signs of good TDD practice:
+- Tests clearly specify expected behavior
+- Tests are written at the right abstraction level
+- Tests fail for the right reasons
+- Tests serve as documentation
+
+Warning signs:
+- Tests that merely mirror implementation details
+- Tests added as an afterthought (testing what exists, not what should exist)
+- Tests that are too tightly coupled to implementation
+- Missing tests for error cases or edge cases
+
+## Uncertainty Guidance
+
+If you are uncertain about test quality:
+- State what you cannot determine from the diff alone
+- Explain what additional context would help
+- Provide your best assessment while noting limitations
+
+For example:
+- "Without seeing the implementation, I cannot confirm if edge case X is adequately covered..."
+- "I am uncertain whether this test is flaky because..."
+
+## Output Format
+
+### Summary
+[Brief description of test changes]
+
+### Test Quality Analysis
+
+#### Coverage
+- **Assessment**: [Your evaluation]
+- **Reasoning**: [Why you reached this conclusion]
+- **Gaps identified**: [Any missing coverage]
+
+#### Isolation
+- **Assessment**: [Your evaluation]
+- **Reasoning**: [Evidence from the diff]
+
+#### Clarity
+- **Assessment**: [Your evaluation]
+- **Specific examples**: [Good or problematic test names/assertions]
+
+#### Maintainability
+- **Assessment**: [Your evaluation]
+- **Concerns**: [Any maintenance issues foreseen]
+
+### TDD Compliance
+
+- **Assessment**: [Compliant / Partially Compliant / Non-Compliant / Cannot Determine]
+- **Reasoning**: [Evidence for your assessment]
+- **Indicators observed**: [What suggests this assessment]
+
+### Uncertainty (if any)
+[What you cannot determine and what would help]
+
+### Recommendations
+
+#### Required Changes
+[Issues that must be addressed]
+
+#### Suggested Improvements
+[Non-blocking suggestions to improve test quality]
+"""

--- a/orchestration/prompts/router_prompt.py
+++ b/orchestration/prompts/router_prompt.py
@@ -1,1 +1,139 @@
-"""Prompt templates for task classification and routing."""
+"""Prompt templates for the router agent.
+
+These prompts support task classification and decomposition. The classify
+prompt is a fallback for when pattern matching fails (P6) - most classification
+should happen in code. All prompts require reasoning first (P3) and allow
+uncertainty (P16).
+"""
+
+
+def classify_task_prompt(task_description: str) -> str:
+    """Generate a prompt to classify an ambiguous task.
+
+    This is a fallback for when deterministic pattern matching fails.
+    Most task classification should happen in code (P6); this prompt
+    only fires when pattern matching returns 'unknown'.
+
+    Args:
+        task_description: The description of the task to classify.
+
+    Returns:
+        A formatted prompt string for task classification.
+    """
+    return f"""You are a task classification agent. Your job is to categorize an ambiguous task into one of the predefined categories.
+
+## Task Description
+{task_description}
+
+## Available Categories
+
+- **code_change**: Tasks requiring modifications to source code (features, bug fixes, refactoring)
+- **code_review**: Tasks requiring review of existing code or pull requests
+- **documentation**: Tasks requiring creation or modification of documentation
+- **testing**: Tasks focused on writing, modifying, or running tests
+- **infrastructure**: Tasks related to CI/CD, deployment, or tooling configuration
+- **research**: Tasks requiring investigation, analysis, or information gathering
+- **unknown**: Use ONLY if the task genuinely does not fit any category above
+
+## Instructions
+
+1. **Analyze the task**: Read the task description carefully and identify key indicators.
+2. **Reason before classifying**: Explain your reasoning process:
+   - What keywords or phrases suggest certain categories?
+   - What is the primary goal of the task?
+   - Are there secondary aspects that suggest other categories?
+3. **Classify**: Only after reasoning, provide your classification.
+
+## Uncertainty Guidance
+
+If the task could reasonably fit multiple categories:
+- Identify the PRIMARY category based on the main goal
+- Note secondary categories if applicable
+- If genuinely ambiguous, explain why and suggest requesting clarification
+
+If you cannot confidently classify the task, use 'unknown' and explain what additional information would help.
+
+## Output Format
+
+### Reasoning
+[Your analysis of the task and reasoning for classification]
+
+### Uncertainty (if any)
+[Any ambiguity or alternative interpretations]
+
+### Classification
+Primary: [category]
+Secondary (if applicable): [category]
+Confidence: [high/medium/low]
+"""
+
+
+def decompose_task_prompt(task_description: str) -> str:
+    """Generate a prompt to break a complex task into subtasks.
+
+    Args:
+        task_description: The description of the complex task to decompose.
+
+    Returns:
+        A formatted prompt string for task decomposition.
+    """
+    return f"""You are a task decomposition agent. Your job is to break a complex task into manageable subtasks that can be executed independently or in sequence.
+
+## Task Description
+{task_description}
+
+## Instructions
+
+1. **Understand the task**: Identify the overall goal and scope of the task.
+2. **Identify components**: Break down the task into logical components.
+3. **Reason about dependencies**: Think through:
+   - Which subtasks can be done in parallel?
+   - Which subtasks depend on others?
+   - What is the optimal ordering?
+4. **Define subtasks**: Only after reasoning, list the subtasks with clear descriptions.
+
+## Subtask Guidelines
+
+Each subtask should:
+- Be independently executable or have clear dependencies noted
+- Have a clear, measurable completion criterion
+- Be appropriately sized (not too large, not too granular)
+- Include any context needed for execution
+
+## Uncertainty Guidance
+
+If you are uncertain about the decomposition:
+- Note which aspects of the task are unclear
+- Suggest what clarification would help
+- Provide your best decomposition while flagging uncertain parts
+
+It is better to acknowledge "This subtask may need further breakdown once X is clarified" than to guess incorrectly.
+
+## Output Format
+
+### Task Analysis
+[Your understanding of the overall task and its scope]
+
+### Reasoning
+[Your thought process for breaking down the task]
+
+### Uncertainty (if any)
+[Any aspects that are unclear or assumptions you made]
+
+### Subtasks
+
+1. **[Subtask Title]**
+   - Description: [What needs to be done]
+   - Dependencies: [None / Subtask numbers this depends on]
+   - Completion Criterion: [How to verify this is done]
+
+2. **[Subtask Title]**
+   - Description: [What needs to be done]
+   - Dependencies: [None / Subtask numbers this depends on]
+   - Completion Criterion: [How to verify this is done]
+
+[Continue as needed...]
+
+### Execution Order
+[Suggested order or parallel execution groups]
+"""


### PR DESCRIPTION
## Summary
- `judge_prompts.py`: `reference_eval_prompt()`, `pairwise_eval_prompt()`, `bias_checklist_prompt()`
- `router_prompt.py`: `classify_task_prompt()`, `decompose_task_prompt()`
- `review_prompts.py`: `review_pr_prompt()`, `scrutinize_test_changes_prompt()`
- All prompts enforce reasoning-before-scores (P3) and include uncertainty guidance (P16)
- Pairwise prompt includes explicit debiasing instructions for position, length, verbosity, and style bias

## Test plan
- [x] All imports verified: `from orchestration.prompts import reference_eval_prompt, classify_task_prompt, review_pr_prompt`
- [x] Each prompt function returns a formatted string with proper variable substitution
- [x] `__init__.py` re-exports all 7 prompt functions

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)