### PR TITLE
Add multi-model ensemble evaluation with backend abstraction

### DIFF
--- a/orchestration/backends.py
+++ b/orchestration/backends.py
@@ -1,0 +1,190 @@
+"""Model backend abstraction for multi-model ensemble evaluation.
+
+Provides a common interface (ModelBackend protocol) for calling different LLM
+providers. Each backend wraps a single provider SDK and exposes a simple
+``complete(prompt) -> str`` method.
+
+Design Principles:
+- P4 Scaffolding > Model: The value is in the uniform interface, not the model.
+- P5 Deterministic Infrastructure: Registry and factory are pure Python.
+- P8 UNIX Philosophy: Each backend does one thing (complete a prompt).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ModelBackend(Protocol):
+    """Protocol for model backends.
+
+    Any class implementing ``complete(prompt: str) -> str`` satisfies this
+    protocol.  Backends are intentionally simple -- they take a prompt string
+    and return the model's text response.
+    """
+
+    def complete(self, prompt: str) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# Economy model defaults (cheaper / faster alternatives)
+# ---------------------------------------------------------------------------
+
+ECONOMY_MODELS: dict[str, str] = {
+    "anthropic": "claude-haiku-4-20250414",
+    "google": "gemini-2.0-flash",
+    "openai": "gpt-4o-mini",
+}
+
+# ---------------------------------------------------------------------------
+# Default (standard) models per provider
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-20250514",
+    "google": "gemini-2.0-flash",
+    "openai": "gpt-4o",
+}
+
+# ---------------------------------------------------------------------------
+# API key environment variable names per provider
+# ---------------------------------------------------------------------------
+
+API_KEY_ENV: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
+
+
+# ---------------------------------------------------------------------------
+# Concrete backend implementations
+# ---------------------------------------------------------------------------
+
+class AnthropicBackend:
+    """Backend using the Anthropic SDK (Claude models)."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.model = model or DEFAULT_MODELS["anthropic"]
+        api_key = os.environ.get(API_KEY_ENV["anthropic"])
+        if not api_key:
+            raise ValueError(
+                f"Missing {API_KEY_ENV['anthropic']} environment variable"
+            )
+        import anthropic
+
+        self._client = anthropic.Anthropic(api_key=api_key)
+
+    def complete(self, prompt: str) -> str:
+        message = self._client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text
+
+
+class GoogleBackend:
+    """Backend using the Google GenAI SDK (Gemini models)."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.model = model or DEFAULT_MODELS["google"]
+        api_key = os.environ.get(API_KEY_ENV["google"])
+        if not api_key:
+            raise ValueError(
+                f"Missing {API_KEY_ENV['google']} environment variable"
+            )
+        from google import genai
+
+        self._client = genai.Client(api_key=api_key)
+
+    def complete(self, prompt: str) -> str:
+        response = self._client.models.generate_content(
+            model=self.model,
+            contents=prompt,
+        )
+        return response.text
+
+
+class OpenAIBackend:
+    """Backend using the OpenAI SDK (GPT models)."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.model = model or DEFAULT_MODELS["openai"]
+        api_key = os.environ.get(API_KEY_ENV["openai"])
+        if not api_key:
+            raise ValueError(
+                f"Missing {API_KEY_ENV['openai']} environment variable"
+            )
+        import openai
+
+        self._client = openai.OpenAI(api_key=api_key)
+
+    def complete(self, prompt: str) -> str:
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content
+
+
+# ---------------------------------------------------------------------------
+# Registry & factory
+# ---------------------------------------------------------------------------
+
+BACKEND_REGISTRY: dict[str, type[ModelBackend]] = {
+    "anthropic": AnthropicBackend,
+    "google": GoogleBackend,
+    "openai": OpenAIBackend,
+}
+
+
+def create_backend(
+    provider: str,
+    model: str | None = None,
+    economy: bool = False,
+) -> ModelBackend:
+    """Create a model backend for the given provider.
+
+    Args:
+        provider: Provider name (``"anthropic"``, ``"google"``, ``"openai"``).
+        model: Override model name.  If ``None``, uses the default (or economy
+            default when *economy* is ``True``).
+        economy: When ``True`` and *model* is ``None``, selects a cheaper model.
+
+    Returns:
+        An instance satisfying the :class:`ModelBackend` protocol.
+
+    Raises:
+        ValueError: If *provider* is not in :data:`BACKEND_REGISTRY`.
+    """
+    if provider not in BACKEND_REGISTRY:
+        raise ValueError(
+            f"Unknown provider: {provider!r}. "
+            f"Available: {', '.join(sorted(BACKEND_REGISTRY))}"
+        )
+
+    if model is None and economy:
+        model = ECONOMY_MODELS.get(provider)
+
+    cls = BACKEND_REGISTRY[provider]
+    return cls(model=model)
+
+
+def available_backends() -> list[str]:
+    """Return provider names that have a valid API key set in the environment."""
+    return [
+        provider
+        for provider, env_var in API_KEY_ENV.items()
+        if os.environ.get(env_var)
+    ]
+
+
+def backend_as_judge_fn(backend: ModelBackend) -> Callable[[str], str]:
+    """Adapt a :class:`ModelBackend` into a ``JudgeFn`` callable.
+
+    The returned callable simply delegates to ``backend.complete()``.
+    """
+    return backend.complete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "ruff>=0.8.0",
     "anthropic>=0.40.0",
     "google-genai>=1.0.0",
+    "openai>=1.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dependencies = [
 dev = [
     { name = "anthropic" },
     { name = "google-genai" },
+    { name = "openai" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -31,6 +32,7 @@ requires-dist = [
 dev = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
@@ -566,6 +568,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/6c/e4c964fcf1d527fdf4739e7cc940c60075a4114d50d03871d5d5b1e13a88/openai-2.16.0.tar.gz", hash = "sha256:42eaa22ca0d8ded4367a77374104d7a2feafee5bd60a107c3c11b5243a11cd12", size = 629649, upload-time = "2026-01-27T23:28:02.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/83/0315bf2cfd75a2ce8a7e54188e9456c60cec6c0cf66728ed07bd9859ff26/openai-2.16.0-py3-none-any.whl", hash = "sha256:5f46643a8f42899a84e80c38838135d7038e7718333ce61396994f887b09a59b", size = 1068612, upload-time = "2026-01-27T23:28:00.356Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -904,6 +925,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Introduce `ModelBackend` protocol with Anthropic, Google, and OpenAI implementations in `orchestration/backends.py`
- Add `multi_model_ensemble()` to `JudgeEngine` for cross-model evaluation with majority vote aggregation, graceful degradation, and cross-model bias checking
- Wire `--provider` and `--model` flags into `eco judge` CLI command for real backend usage
- Add `openai>=1.0.0` to dev dependencies

## Test plan
- [x] 33 backend tests pass (protocol, registry, factory, available_backends, economy mode, SDK mocking)
- [x] 5 new ensemble tests pass (basic, partial failure, all fail, agreement, cross-model bias check)
- [x] Full suite: 158 tests pass
- [ ] Manual: `eco judge --help` shows `--provider` flag
- [ ] Integration: test with real API keys for each provider

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)