### PR TITLE
Implement agent execution pipeline

### DIFF
--- a/orchestration/tests/test_execution.py
+++ b/orchestration/tests/test_execution.py
@@ -140,10 +140,18 @@ class TestExecutionEngine:
 
     def test_execute_real_run(self, tmp_path):
         engine = ExecutionEngine(state_dir=tmp_path / "state")
+
+        def mock_agent(agent, run):
+            return {"agent": agent, "input_tokens": 50, "output_tokens": 30, "output": "done"}
+
+        engine._run_agent = mock_agent  # type: ignore[assignment]
+
         run = engine.plan("Add a login page")
         result = engine.execute(run)
         assert result.status == "complete"
         assert result.dry_run is False
+        assert result.token_usage["input"] > 0
+        assert result.token_usage["output"] > 0
 
     def test_execute_records_run(self, tmp_path):
         state_dir = tmp_path / "state"


### PR DESCRIPTION
## Summary
- **`_run_agent()` in `execution.py`**: Replaced no-op stub with working Anthropic API integration — loads agent definition markdown as system prompt, selects model per agent role, tracks real token usage
- **`cmd_route()` in `cli.py`**: Replaced keyword-matching placeholder with `TaskRouter.route()` (uses full regex classification + routing table)
- **`RUBRICS` in `cli.py`**: Built dynamically from `CODE_REVIEW_RUBRIC` and `TEST_QUALITY_RUBRIC` modules instead of hardcoded dict
- **`cmd_judge()` fallback**: Returns clear error requiring `--provider` instead of fake scores
- **`cmd_review()`**: Uses `review_pr_prompt()` from prompts module with real rubric criteria

## Test plan
- [x] All 369 existing tests pass
- [x] Ruff linter clean
- [x] `agents route "Add a login page"` returns real router output (feature → architect → performance-engineer → orchestrator)
- [x] `agents rubric list` shows code_review and test_quality from real modules
- [x] `agents rubric show code_review` displays real criteria (Correctness, Completeness, Code Quality, Security, Test Quality)
- [x] `agents run --dry-run "Add input validation"` shows execution plan
- [ ] `agents run "task"` with `ANTHROPIC_API_KEY` set invokes agents end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)