### PR TITLE
[Infrastructure] Establish Unity Space Sim labeling conventions

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -44,6 +44,23 @@ Apply one or more of these labels to every issue:
 | `priority:medium` | Important but not blocking |
 | `priority:low` | Nice to have |
 
+**Unity Space Simulation Project Labels:**
+
+| Label | Use when |
+|---|---|
+| `unity-space-sim` | Any Unity Space Sim work |
+| `asset-pipeline` | Blender→Unity asset generation workflows |
+| `blender` | Blender Python scripting, bpy API |
+| `unity-engine` | Unity C# scripts, components, scenes |
+| `gamedev` | Game development features (flight controls, camera, gameplay) |
+| `unity-meta-phase` | Meta Phase orchestration setup work |
+| `unity-phase-1` | Phase 1: Foundation & Documentation |
+| `unity-phase-1.5` | Phase 1.5: MVP - Drivable Ship |
+| `unity-phase-2` | Phase 2: Blender Pipeline |
+| `unity-phase-3` | Phase 3: Unity Integration |
+| `unity-phase-4` | Phase 4: CI/CD Automation |
+| `unity-phase-5` | Phase 5: End-to-End Testing |
+
 ## Body Template
 
 Use this template for the issue body (omit sections that don't apply):


### PR DESCRIPTION
Create GitHub labels for Unity Space Simulation project and update all phase issues with appropriate labels.

## Changes

**Labels Created (11 total):**

**Project Labels:**
- `asset-pipeline` (#0e8a16) - Asset generation pipeline work
- `blender` (#f9d0c4) - Blender Python scripting and bpy API
- `unity-engine` (#000000) - Unity C# scripts and engine integration
- `gamedev` (#d876e3) - Game development and gameplay features

**Phase Labels:**
- `unity-meta-phase` (#fbca04) - Meta Phase: Orchestration setup
- `unity-phase-1` (#fbca04) - Phase 1: Foundation & Documentation
- `unity-phase-1.5` (#fbca04) - Phase 1.5: MVP - Drivable Ship
- `unity-phase-2` (#fbca04) - Phase 2: Blender Pipeline
- `unity-phase-3` (#fbca04) - Phase 3: Unity Integration
- `unity-phase-4` (#fbca04) - Phase 4: CI/CD Automation
- `unity-phase-5` (#fbca04) - Phase 5: End-to-End Testing

**Issues Updated:**
Applied phase labels to all Unity Space Sim issues:
- Meta Phase: #73, #82, #83, #84, #85
- Project Phases: #74, #75, #76, #77, #78, #79

**Documentation:**
Updated `.claude/skills/create-issue/SKILL.md` with Unity Space Sim label reference table for future issue creation.

## Verification

```bash
# Verify all labels exist
gh label list --json name --jq '.[] | select(.name | contains("unity") or contains("asset") or contains("blender") or contains("gamedev")) | .name'

# Verify phase issues have correct labels
gh issue view 73 --json labels --jq '.labels[].name' | grep unity-meta-phase
gh issue view 74 --json labels --jq '.labels[].name' | grep unity-phase-1
gh issue view 79 --json labels --jq '.labels[].name' | grep unity-phase-1.5

# Verify create-issue skill docs mention new labels
grep -A 10 "unity-space-sim\|asset-pipeline\|blender\|gamedev" .claude/skills/create-issue/SKILL.md
```

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)