### PR TITLE
Enable package mode for CLI entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,16 @@ dev = [
 agents = "orchestration.cli:main"
 eco = "orchestration.cli:main"
 
+[tool.uv]
+package = true
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["orchestration"]
+
 [tool.pytest.ini_options]
 testpaths = ["orchestration/tests"]
 markers = ["integration: end-to-end integration tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,7 @@ requires-python = ">=3.10"
 [[package]]
 name = "agents"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "arcadepy" },
     { name = "pytest" },


### PR DESCRIPTION
## Summary
- Add hatchling build system and `tool.uv.package = true` to `pyproject.toml` so `uv sync` installs the `agents` and `eco` CLI entry points
- Resolves the "Skipping installation of entry points" warning during `uv sync`

## Test plan
- [ ] Run `uv sync` — completes without warnings
- [ ] Run `uv run agents --help` — CLI works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)