### PR TITLE
Align GCP env var names with .env.example

### DIFF
--- a/orchestration/config.py
+++ b/orchestration/config.py
@@ -171,14 +171,14 @@ def _build_config(section: dict[str, Any]) -> EcoConfig:
         poll_interval=poll_interval,
         parallel=parallel,
         models=models,
-        gcp_project=os.environ.get("ECO_GCP_PROJECT", gcp.get("project")),
-        gcp_zone=os.environ.get("ECO_GCP_ZONE", gcp.get("zone", "us-central1-a")),
+        gcp_project=os.environ.get("GCP_PROJECT", gcp.get("project")),
+        gcp_zone=os.environ.get("GCP_ZONE", gcp.get("zone", "us-central1-a")),
         gcp_machine_type=os.environ.get(
-            "ECO_GCP_MACHINE_TYPE", gcp.get("machine_type", "e2-standard-2"),
+            "GCP_MACHINE_TYPE", gcp.get("machine_type", "e2-standard-2"),
         ),
         gcp_timeout_hours=int(
             os.environ.get(
-                "ECO_GCP_TIMEOUT_HOURS",
+                "GCP_TIMEOUT_HOURS",
                 gcp.get("timeout_hours", 4),
             )
         ),

--- a/orchestration/tests/test_config.py
+++ b/orchestration/tests/test_config.py
@@ -228,7 +228,7 @@ class TestBuildConfig:
         config = _build_config({})
         assert config.parallel is False
 
-    @patch.dict(os.environ, {"ECO_GCP_PROJECT": "env-project"})
+    @patch.dict(os.environ, {"GCP_PROJECT": "env-project"})
     def test_env_overrides_gcp_project(self):
         config = _build_config({"gcp": {"project": "file-project"}})
         assert config.gcp_project == "env-project"


### PR DESCRIPTION
## Summary
- Renamed `ECO_GCP_PROJECT`, `ECO_GCP_ZONE`, `ECO_GCP_MACHINE_TYPE`, `ECO_GCP_TIMEOUT_HOURS` to `GCP_PROJECT`, `GCP_ZONE`, `GCP_MACHINE_TYPE`, `GCP_TIMEOUT_HOURS` in `orchestration/config.py` to match the names defined in `.env.example`
- Updated corresponding test in `orchestration/tests/test_config.py`

## Test plan
- [x] All 39 tests in `test_config.py` pass
- [ ] Verify no deployed environments rely on the old `ECO_GCP_*` variable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)