### PR TITLE
Fix environment variable loading and routing patterns

### DIFF
--- a/orchestration/cli.py
+++ b/orchestration/cli.py
@@ -35,6 +35,8 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any
 
+from dotenv import load_dotenv
+
 from orchestration.cost import (
     CostCalculator,
     DailySummary,
@@ -1724,6 +1726,9 @@ def main() -> int:
     When economy mode is active, ``args.economy`` is ``True`` and downstream
     modules should select smaller, cheaper models accordingly.
     """
+    # Load environment variables from .env file
+    load_dotenv()
+
     parser = create_parser()
     args = parser.parse_args()
 

--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -115,7 +115,17 @@ PRIORITY_TABLE: dict[TaskType, str] = {
 # Classification patterns - ordered by specificity (most specific first)
 # Pattern matching handles known task types (P6: Code Before Prompts)
 CLASSIFICATION_PATTERNS: list[tuple[TaskType, re.Pattern]] = [
-    # Unity Space Sim project-specific patterns (most specific, checked first)
+    # Architecture and documentation patterns (MUST come first, before project-specific)
+    # These override project-specific routing when the task is clearly about architecture/docs
+    (TaskType.ARCHITECTURE, re.compile(r"\barchitecture\b", re.IGNORECASE)),
+    (TaskType.ARCHITECTURE, re.compile(r"\bsystem\s*design\b", re.IGNORECASE)),
+    (TaskType.ARCHITECTURE, re.compile(r"\bapi\s*spec\b", re.IGNORECASE)),
+    (TaskType.ARCHITECTURE, re.compile(r"\bfoundation\b.*\bdocumentation\b", re.IGNORECASE)),
+    (TaskType.ARCHITECTURE, re.compile(r"\bproject\s+foundation\b", re.IGNORECASE)),
+    (TaskType.DOCS, re.compile(r"\bwrite.*documentation\b", re.IGNORECASE)),
+    (TaskType.DOCS, re.compile(r"\bcreate.*documentation\b", re.IGNORECASE)),
+    (TaskType.DOCS, re.compile(r"\barchitectural\s+documentation\b", re.IGNORECASE)),
+    # Unity Space Sim project-specific patterns (most specific, checked after architecture/docs)
     # Asset design patterns (most specific - must come before general Unity/Blender)
     (TaskType.UNITY_ASSET_DESIGN, re.compile(r"\bship\s+design\b", re.IGNORECASE)),
     (TaskType.UNITY_ASSET_DESIGN, re.compile(r"\basset\s+design\b", re.IGNORECASE)),
@@ -148,10 +158,6 @@ CLASSIFICATION_PATTERNS: list[tuple[TaskType, re.Pattern]] = [
     (TaskType.DESIGN, re.compile(r"\bui\b", re.IGNORECASE)),
     (TaskType.DESIGN, re.compile(r"\bux\b", re.IGNORECASE)),
     (TaskType.DESIGN, re.compile(r"\bwireframe\b", re.IGNORECASE)),
-    # Architecture patterns
-    (TaskType.ARCHITECTURE, re.compile(r"\barchitecture\b", re.IGNORECASE)),
-    (TaskType.ARCHITECTURE, re.compile(r"\bsystem\s*design\b", re.IGNORECASE)),
-    (TaskType.ARCHITECTURE, re.compile(r"\bapi\s*spec\b", re.IGNORECASE)),
     # Backend patterns
     (TaskType.BACKEND, re.compile(r"\bapi\b", re.IGNORECASE)),
     (TaskType.BACKEND, re.compile(r"\bdatabase\b", re.IGNORECASE)),
@@ -190,9 +196,8 @@ CLASSIFICATION_PATTERNS: list[tuple[TaskType, re.Pattern]] = [
     (TaskType.BUG_FIX, re.compile(r"\bbroken\b", re.IGNORECASE)),
     (TaskType.BUG_FIX, re.compile(r"\berror\b", re.IGNORECASE)),
     (TaskType.BUG_FIX, re.compile(r"\bissue\b", re.IGNORECASE)),
-    # Docs patterns
+    # Docs patterns (additional fallback patterns - more specific ones are at top)
     (TaskType.DOCS, re.compile(r"\bdocs?\b", re.IGNORECASE)),
-    (TaskType.DOCS, re.compile(r"\bdocumentation\b", re.IGNORECASE)),
     (TaskType.DOCS, re.compile(r"\breadme\b", re.IGNORECASE)),
     (TaskType.DOCS, re.compile(r"\bdocstrings?\b", re.IGNORECASE)),
     # Infrastructure patterns


### PR DESCRIPTION
## Summary

Fixes critical issues in the orchestration system:
- ✅ All agents now source `.env` automatically 
- ✅ Architecture tasks route to `architect` agent correctly

## Changes

**orchestration/cli.py:**
- Add `dotenv` import and `load_dotenv()` call in `main()`
- Ensures ANTHROPIC_API_KEY and other env vars are accessible to agents

**orchestration/router.py:**
- Move architecture/documentation patterns to top priority (before Unity-specific patterns)
- Add specific patterns: `foundation.*documentation`, `project foundation`, `architectural documentation`
- Prevents Unity project tasks from always routing to `unity-engineer`

## Testing

```bash
# Verify env loading
uv run agents route "test task"  # Should work without errors

# Verify routing fix
uv run agents route "Set up project architecture and write documentation"
# Expected: task_type=architecture, sequence=architect
# Before fix: task_type=unity_scripting, sequence=unity-engineer
```

## Impact

- **Environment variables**: Agents can now access API keys from `.env`
- **Routing**: Documentation/architecture tasks route correctly regardless of project context

## Related Issues

- Discovered while working on #74 (Unity Space Sim Phase 1)
- Fixes agent execution failures due to missing ANTHROPIC_API_KEY
- Fixes incorrect routing for foundation/documentation tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)